### PR TITLE
BE_MessageDigest returns incorrect result when input contains Japanese characters

### DIFF
--- a/Source/BEPluginUtilities.cpp
+++ b/Source/BEPluginUtilities.cpp
@@ -224,7 +224,7 @@ StringAutoPtr ParameterAsUTF8String ( const DataVect& parameters, const FMX_UInt
 		TextAutoPtr raw_data;
 		raw_data->SetText ( parameters.AtAsText ( which ) );
 		
-		FMX_UInt32 text_size = (2*(raw_data->GetSize())) + 1;
+		FMX_UInt32 text_size = (4*(raw_data->GetSize())) + 1;
 		char * text = new char [ text_size ]();
 		raw_data->GetBytes ( text, text_size, 0, (FMX_UInt32)Text::kSize_End, Text::kEncoding_UTF8 );
 		result->assign ( text );


### PR DESCRIPTION
Japanese characters require three or four bytes in UTF-8, so the buffer size should be (text length \* 4 + 1).
Please let me know if I should add a new test case to _BaseElements Plugin Tests.fmp12_.

And thank you for releasing a useful plugin under permissive license!

p.s.
Actually, it seems that `(3*(raw_data->GetSize())) + 1` works fine because the fmx::Text->GetSize() returns 2 for a character which requires four bytes in UTF-8 (at least on Mac OS X 10.9), but I am not sure if it's a bug or a designed behavior.
