### PR TITLE
UTF-8 characters can consume 4 bytes maximum.

### DIFF
--- a/Source/BEPluginUtilities.cpp
+++ b/Source/BEPluginUtilities.cpp
@@ -741,7 +741,7 @@ string TextAsUTF8String ( const Text& fmx_text )
 	
 	try {
 		
-		FMX_UInt32 text_size = (2*(fmx_text.GetSize())) + 1;
+		FMX_UInt32 text_size = (4*(fmx_text.GetSize())) + 1;
 		char * text = new char [ text_size ]();
 		fmx_text.GetBytes ( text, text_size, 0, (FMX_UInt32)Text::kSize_End, Text::kEncoding_UTF8 );
 		result.assign ( text );


### PR DESCRIPTION
This is essentially the same fix as #50 .
As a result of some refactoring, ParameterAsUTF8String now calls TextAsUTF8String which still uses ((2 * text size) + 1) as the buffer size.
