### PR TITLE
Less environment dependent project settings.

### DIFF
--- a/Project/BaseElements.xcodeproj/project.pbxproj
+++ b/Project/BaseElements.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 				4D362AA61F2085880036B751 /* BaseElementsIOSSimulator.fmplugin */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		C7DEDEF607E10BF3002283F3 /* Sources */ = {
 			isa = PBXGroup;

--- a/Project/BaseElements.xcodeproj/project.pbxproj
+++ b/Project/BaseElements.xcodeproj/project.pbxproj
@@ -1298,7 +1298,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_LINK_OBJC_RUNTIME = NO;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Applications/FileMaker Pro 16 Advanced/Extensions/";
+				CONFIGURATION_BUILD_DIR = "${USER_LIBRARY_DIR}/Application Support/FileMaker/Extensions";
 				DEAD_CODE_STRIPPING = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -1332,7 +1332,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_LINK_OBJC_RUNTIME = NO;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Applications/FileMaker Pro 16 Advanced/Extensions/";
+				CONFIGURATION_BUILD_DIR = "${USER_LIBRARY_DIR}/Application Support/FileMaker/Extensions";
 				DEAD_CODE_STRIPPING = YES;
 				DEPLOYMENT_POSTPROCESSING = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
- Use tabs for indentation. This helps if user wants to use spaces by default.
- Output the compiled plugin to version-independent directory inside user's home.
