### PR TITLE
Functions to generate and verify digital signature using RSA key pair.

### DIFF
--- a/Project/BaseElements.xcodeproj/project.pbxproj
+++ b/Project/BaseElements.xcodeproj/project.pbxproj
@@ -224,6 +224,9 @@
 		4DCD49711A195B0C00EFCF7F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D27C3851861160000E7F4A1 /* Cocoa.framework */; };
 		4DD510241DD136F200763F7E /* libjansson.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4DD510231DD136F200763F7E /* libjansson.a */; };
 		6570DD341E0107D8007B61E7 /* FMWrapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D05792C1B3B83550000585F /* FMWrapper.framework */; };
+		B282D74C201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B282D74B201C9DBE0074C4BE /* BEOpenSSLRSA.cpp */; };
+		B282D74D201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B282D74B201C9DBE0074C4BE /* BEOpenSSLRSA.cpp */; };
+		B282D74E201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B282D74B201C9DBE0074C4BE /* BEOpenSSLRSA.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -260,7 +263,7 @@
 		4D1BFE551F3AC9A600805CD3 /* libpodofo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpodofo.a; path = ../Libraries/iOS/libpodofo.a; sourceTree = "<group>"; };
 		4D1BFE581F3ACAF200805CD3 /* libbz2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/usr/lib/libbz2.tbd; sourceTree = DEVELOPER_DIR; };
 		4D1D070B1F21C36700BCE550 /* BEAppleFunctionsCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEAppleFunctionsCommon.h; path = ../Source/BEAppleFunctionsCommon.h; sourceTree = "<group>"; };
-		4D1D070C1F21C36700BCE550 /* BEAppleFunctionsCommon.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = BEAppleFunctionsCommon.mm; path = ../Source/BEAppleFunctionsCommon.mm; sourceTree = "<group>"; };
+		4D1D070C1F21C36700BCE550 /* BEAppleFunctionsCommon.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = BEAppleFunctionsCommon.mm; path = ../Source/BEAppleFunctionsCommon.mm; sourceTree = "<group>"; usesTabs = 1; };
 		4D25BF9A1F3A8C580083345B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/BaseElements.strings; sourceTree = "<group>"; };
 		4D25BF9F1F3A8C5F0083345B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/BEPluginVersion.strings; sourceTree = "<group>"; };
 		4D25BFA11F3A8CC90083345B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/BEPluginVersion.strings; sourceTree = "<group>"; };
@@ -312,7 +315,7 @@
 		4D362AA61F2085880036B751 /* BaseElementsIOSSimulator.fmplugin */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BaseElementsIOSSimulator.fmplugin; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D37E0B11339CF080084730B /* BECurl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BECurl.cpp; path = ../Source/BECurl.cpp; sourceTree = SOURCE_ROOT; };
 		4D37E0B21339CF080084730B /* BECurl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BECurl.h; path = ../Source/BECurl.h; sourceTree = SOURCE_ROOT; };
-		4D3969C618DA54CA00DFC47A /* BEOpenSSLAES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BEOpenSSLAES.cpp; sourceTree = "<group>"; };
+		4D3969C618DA54CA00DFC47A /* BEOpenSSLAES.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BEOpenSSLAES.cpp; sourceTree = "<group>"; usesTabs = 1; };
 		4D3969C718DA54CA00DFC47A /* BEOpenSSLAES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BEOpenSSLAES.h; sourceTree = "<group>"; };
 		4D3969C918DA773900DFC47A /* BEBase64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BEBase64.cpp; sourceTree = "<group>"; };
 		4D3969CA18DA773900DFC47A /* BEBase64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BEBase64.h; sourceTree = "<group>"; };
@@ -371,10 +374,10 @@
 		4D9E26D21B292032002F7DD3 /* BEBio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BEBio.h; sourceTree = "<group>"; };
 		4D9F2DD611E934BC003D75BB /* BEMacFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEMacFunctions.h; path = ../Source/BEMacFunctions.h; sourceTree = SOURCE_ROOT; };
 		4D9F2DD711E934BC003D75BB /* BEMacFunctions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = BEMacFunctions.mm; path = ../Source/BEMacFunctions.mm; sourceTree = SOURCE_ROOT; };
-		4D9F2DD811E934BC003D75BB /* BEPlugin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BEPlugin.cpp; path = ../Source/BEPlugin.cpp; sourceTree = SOURCE_ROOT; };
-		4D9F2DD911E934BC003D75BB /* BEPluginFunctions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BEPluginFunctions.cpp; path = ../Source/BEPluginFunctions.cpp; sourceTree = SOURCE_ROOT; };
+		4D9F2DD811E934BC003D75BB /* BEPlugin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BEPlugin.cpp; path = ../Source/BEPlugin.cpp; sourceTree = SOURCE_ROOT; usesTabs = 1; };
+		4D9F2DD911E934BC003D75BB /* BEPluginFunctions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BEPluginFunctions.cpp; path = ../Source/BEPluginFunctions.cpp; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 		4D9F2DDA11E934BC003D75BB /* BEPluginFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEPluginFunctions.h; path = ../Source/BEPluginFunctions.h; sourceTree = SOURCE_ROOT; };
-		4D9F2DDB11E934BC003D75BB /* BEPluginGlobalDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEPluginGlobalDefines.h; path = ../Source/BEPluginGlobalDefines.h; sourceTree = SOURCE_ROOT; };
+		4D9F2DDB11E934BC003D75BB /* BEPluginGlobalDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEPluginGlobalDefines.h; path = ../Source/BEPluginGlobalDefines.h; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 		4DAC555318BDA41E00F365F5 /* BESMTP.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BESMTP.cpp; path = ../Source/BESMTP.cpp; sourceTree = "<group>"; };
 		4DAC555418BDA41E00F365F5 /* BESMTP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BESMTP.h; path = ../Source/BESMTP.h; sourceTree = "<group>"; };
 		4DB857A11C646DF600D0192A /* BESMTPContainerAttachments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BESMTPContainerAttachments.cpp; path = ../Source/BESMTPContainerAttachments.cpp; sourceTree = "<group>"; };
@@ -399,6 +402,8 @@
 		4DFDF48F1BF992A100B4C7C4 /* BEPluginVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BEPluginVersion.h; path = ../Source/BEPluginVersion.h; sourceTree = "<group>"; };
 		4DFFF8B11884A0390015B531 /* BEXero.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BEXero.cpp; path = ../Source/BEXero.cpp; sourceTree = "<group>"; };
 		4DFFF8B21884A0390015B531 /* BEXero.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEXero.h; path = ../Source/BEXero.h; sourceTree = "<group>"; };
+		B282D74A201C9B540074C4BE /* BEOpenSSLRSA.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BEOpenSSLRSA.h; sourceTree = "<group>"; };
+		B282D74B201C9DBE0074C4BE /* BEOpenSSLRSA.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BEOpenSSLRSA.cpp; sourceTree = "<group>"; usesTabs = 1; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -551,6 +556,8 @@
 				4D3969C918DA773900DFC47A /* BEBase64.cpp */,
 				4D3969C718DA54CA00DFC47A /* BEOpenSSLAES.h */,
 				4D3969C618DA54CA00DFC47A /* BEOpenSSLAES.cpp */,
+				B282D74A201C9B540074C4BE /* BEOpenSSLRSA.h */,
+				B282D74B201C9DBE0074C4BE /* BEOpenSSLRSA.cpp */,
 				4D156AE1135D8BC2001A249B /* BEMessageDigest.h */,
 				4D156AE2135D8BC2001A249B /* BEMessageDigest.cpp */,
 				4D9E26CE1B29069B002F7DD3 /* BEX509.cpp */,
@@ -941,6 +948,7 @@
 				4D3629F41F2079A60036B751 /* BECurlOption.cpp in Sources */,
 				4D3629F51F2079A60036B751 /* BESMTPEmailMessage.cpp in Sources */,
 				4D3629F61F2079A60036B751 /* BESMTPContainerAttachments.cpp in Sources */,
+				B282D74C201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */,
 				4D3629F71F2079A60036B751 /* BEBase64.cpp in Sources */,
 				4D3629F81F2079A60036B751 /* BEOpenSSLAES.cpp in Sources */,
 				4D3629F91F2079A60036B751 /* BEMessageDigest.cpp in Sources */,
@@ -987,6 +995,7 @@
 				4D362A761F2085880036B751 /* BECurlOption.cpp in Sources */,
 				4D362A771F2085880036B751 /* BESMTPEmailMessage.cpp in Sources */,
 				4D362A781F2085880036B751 /* BESMTPContainerAttachments.cpp in Sources */,
+				B282D74E201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */,
 				4D362A791F2085880036B751 /* BEBase64.cpp in Sources */,
 				4D362A7A1F2085880036B751 /* BEOpenSSLAES.cpp in Sources */,
 				4D362A7B1F2085880036B751 /* BEMessageDigest.cpp in Sources */,
@@ -1015,6 +1024,7 @@
 				4DCD494B1A195B0C00EFCF7F /* BEPluginFunctions.cpp in Sources */,
 				4DCD494C1A195B0C00EFCF7F /* BEPluginUtilities.cpp in Sources */,
 				4D668AA81A36BF0300D14592 /* BEJavaScript.cpp in Sources */,
+				B282D74D201C9DBF0074C4BE /* BEOpenSSLRSA.cpp in Sources */,
 				4DCD494D1A195B0C00EFCF7F /* BEFileMakerPlugin.cpp in Sources */,
 				4DCD494E1A195B0C00EFCF7F /* BEXSLT.cpp in Sources */,
 				4D8D8E161B167A2C005FEBD3 /* BEQuadChar.cpp in Sources */,

--- a/Resources/de.lproj/BaseElements.strings
+++ b/Resources/de.lproj/BaseElements.strings
@@ -107,6 +107,8 @@
 "460" = "BE_FMS_Open_Files ( username ; password {; files } )||BaseElements Internal : function not yet documented.";
 "500" = "BE_Encrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptEncrypt(data;key) instead.";
 "501" = "BE_Decrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptDecrypt(container;key) instead.";
+"502" = "BE_SignatureGenerate_RSA ( data ; privateKey {; privateKeyPassword ; algorithm; fileNameWithExtension } )||Generate a digital signature of text using privateKey.";
+"503" = "BE_SignatureVerify_RSA ( data ; publicKey ; signature {; algorithm } )||Verify singature using publicKey.";
 "550" = "BE_HMAC_Deprecated ( text ; key {; algorithm ; outputEncoding ; inputEncoding } )||Deprecated.  Use the FileMaker 16 function CryptAuthCode(data;algorithm;key) instead.";
 "600" = "BE_EvaluateJavaScript ( javaScript )||BaseElements Internal : function not yet documented.";
 "650" = "BE_ArraySetFromValueList ( valueList )|Array Set ValueList|Stores the ValueList as an array within the plugin memory space and returns an index number that you can use to reference the array via memory.";

--- a/Resources/en.lproj/BaseElements.strings
+++ b/Resources/en.lproj/BaseElements.strings
@@ -107,6 +107,8 @@
 "460" = "BE_FMS_Open_Files ( username ; password {; files } )||BaseElements Internal : function not yet documented.";
 "500" = "BE_Encrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptEncrypt(data;key) instead.";
 "501" = "BE_Decrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptDecrypt(container;key) instead.";
+"502" = "BE_SignatureGenerate_RSA ( data ; privateKey {; privateKeyPassword ; algorithm; fileNameWithExtension } )||Generate a digital signature of text using privateKey.";
+"503" = "BE_SignatureVerify_RSA ( data ; publicKey ; signature {; algorithm } )||Verify singature using publicKey.";
 "550" = "BE_HMAC_Deprecated ( text ; key {; algorithm ; outputEncoding ; inputEncoding } )||Deprecated.  Use the FileMaker 16 function CryptAuthCode(data;algorithm;key) instead.";
 "600" = "BE_EvaluateJavaScript ( javaScript )||BaseElements Internal : function not yet documented.";
 "650" = "BE_ArraySetFromValueList ( valueList )|Array Set ValueList|Stores the ValueList as an array within the plugin memory space and returns an index number that you can use to reference the array via memory.";

--- a/Resources/ja.lproj/BaseElements.strings
+++ b/Resources/ja.lproj/BaseElements.strings
@@ -107,6 +107,8 @@
 "460" = "BE_FMS_Open_Files ( username ; password {; files } )||BaseElements Internal : function not yet documented.";
 "500" = "BE_Encrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptEncrypt(data;key) instead.";
 "501" = "BE_Decrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptDecrypt(container;key) instead.";
+"502" = "BE_SignatureGenerate_RSA ( data ; privateKey {; privateKeyPassword ; algorithm; fileNameWithExtension } )||Generate a digital signature of text using privateKey.";
+"503" = "BE_SignatureVerify_RSA ( data ; publicKey ; signature {; algorithm } )||Verify singature using publicKey.";
 "550" = "BE_HMAC_Deprecated ( text ; key {; algorithm ; outputEncoding ; inputEncoding } )||Deprecated.  Use the FileMaker 16 function CryptAuthCode(data;algorithm;key) instead.";
 "600" = "BE_EvaluateJavaScript ( javaScript )||BaseElements Internal : function not yet documented.";
 "650" = "BE_ArraySetFromValueList ( valueList )|Array Set ValueList|Stores the ValueList as an array within the plugin memory space and returns an index number that you can use to reference the array via memory.";

--- a/Resources/zh-Hans.lproj/BaseElements.strings
+++ b/Resources/zh-Hans.lproj/BaseElements.strings
@@ -107,6 +107,8 @@
 "460" = "BE_FMS_Open_Files ( username ; password {; files } )||BaseElements Internal : function not yet documented.";
 "500" = "BE_Encrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptEncrypt(data;key) instead.";
 "501" = "BE_Decrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptDecrypt(container;key) instead.";
+"502" = "BE_SignatureGenerate_RSA ( data ; privateKey {; privateKeyPassword ; algorithm; fileNameWithExtension } )||Generate a digital signature of text using privateKey.";
+"503" = "BE_SignatureVerify_RSA ( data ; publicKey ; signature {; algorithm } )||Verify singature using publicKey.";
 "550" = "BE_HMAC_Deprecated ( text ; key {; algorithm ; outputEncoding ; inputEncoding } )||Deprecated.  Use the FileMaker 16 function CryptAuthCode(data;algorithm;key) instead.";
 "600" = "BE_EvaluateJavaScript ( javaScript )||BaseElements Internal : function not yet documented.";
 "650" = "BE_ArraySetFromValueList ( valueList )|Array Set ValueList|Stores the ValueList as an array within the plugin memory space and returns an index number that you can use to reference the array via memory.";

--- a/Resources/zh-Hant.lproj/BaseElements.strings
+++ b/Resources/zh-Hant.lproj/BaseElements.strings
@@ -107,6 +107,8 @@
 "460" = "BE_FMS_Open_Files ( username ; password {; files } )||BaseElements Internal : function not yet documented.";
 "500" = "BE_Encrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptEncrypt(data;key) instead.";
 "501" = "BE_Decrypt_AES_Deprecated ( key ; text )||Deprecated.  Use the FileMaker 16 function CryptDecrypt(container;key) instead.";
+"502" = "BE_SignatureGenerate_RSA ( data ; privateKey {; privateKeyPassword ; algorithm; fileNameWithExtension } )||Generate a digital signature of text using privateKey.";
+"503" = "BE_SignatureVerify_RSA ( data ; publicKey ; signature {; algorithm } )||Verify singature using publicKey.";
 "550" = "BE_HMAC_Deprecated ( text ; key {; algorithm ; outputEncoding ; inputEncoding } )||Deprecated.  Use the FileMaker 16 function CryptAuthCode(data;algorithm;key) instead.";
 "600" = "BE_EvaluateJavaScript ( javaScript )||BaseElements Internal : function not yet documented.";
 "650" = "BE_ArraySetFromValueList ( valueList )|Array Set ValueList|Stores the ValueList as an array within the plugin memory space and returns an index number that you can use to reference the array via memory.";

--- a/Source/BEPlugin.cpp
+++ b/Source/BEPlugin.cpp
@@ -188,6 +188,8 @@ static FMX_Int32 LoadPlugin ( FMX_ExternCallPtr plugin_call )
 
 	g_be_plugin->RegisterHiddenFunction ( kBE_Encrypt_AES_Deprecated, BE_Encrypt_AES_Deprecated, 2 );
 	g_be_plugin->RegisterHiddenFunction ( kBE_Decrypt_AES_Deprecated, BE_Decrypt_AES_Deprecated, 2 );
+	g_be_plugin->RegisterFunction ( kBE_SignatureGenerate_RSA, BE_SignatureGenerate_RSA, 2, 5 );
+	g_be_plugin->RegisterFunction ( kBE_SignatureVerify_RSA, BE_SignatureVerify_RSA, 3, 4 );
 
 
 	g_be_plugin->RegisterFunction ( kBE_HTTP_POST, BE_HTTP_POST_PUT_PATCH, 2, 5 );

--- a/Source/BEPluginFunctions.h
+++ b/Source/BEPluginFunctions.h
@@ -151,6 +151,8 @@ fmx::errcode BE_InstallScriptStep ( short /* function_id */, const fmx::ExprEnv&
 fmx::errcode BE_RemoveScriptStep ( short /* function_id */, const fmx::ExprEnv& /* environment */, const fmx::DataVect& parameters, fmx::Data& reply );
 fmx::errcode BE_PerformScriptStep ( short function_id, const fmx::ExprEnv& environment, const fmx::DataVect& parameters, fmx::Data& reply );
 
+fmx::errcode BE_SignatureGenerate_RSA ( short funcId, const fmx::ExprEnv& environment, const fmx::DataVect& parameters, fmx::Data& results );
+fmx::errcode BE_SignatureVerify_RSA ( short funcId, const fmx::ExprEnv& environment, const fmx::DataVect& parameters, fmx::Data& results );
 
 // Deprecated
 

--- a/Source/BEPluginGlobalDefines.h
+++ b/Source/BEPluginGlobalDefines.h
@@ -221,6 +221,8 @@ enum functions {
 	kBE_FMS_Open_Files = 460,
 	kBE_Encrypt_AES_Deprecated = 500,
 	kBE_Decrypt_AES_Deprecated = 501,
+	kBE_SignatureGenerate_RSA = 502,
+	kBE_SignatureVerify_RSA = 503,
 	kBE_HMAC_Deprecated = 550,
 //	kBE_Encoding_TextToHex = 570, // removed
 //	kBE_Encoding_HexToText = 571, // removed
@@ -288,7 +290,16 @@ enum errors {
     kMessageDigestDecodeKeyError = 16000,
     kMessageDigestDecodeMessageError = 16001,
 	kHexEncodingFailed = 16002,
-	kHexDecodingFailed = 16003
+	kHexDecodingFailed = 16003,
+	kRSALoadBioFailed = 17000,
+	kRSAReadPrivateKeyFailed = 17001,
+	kRSAReadPublicKeyFailed = 17002,
+	kRSASignInitFailed = 17003,
+	kRSASignUpdateFailed = 17003,
+	kRSASignFinalFailed = 17004,
+	kRSAVerifyInitFailed = 17005,
+	kRSAVerifyUpdateFailed = 17006,
+	kRSATranslateDigestFailed = 17007
 };
 
 

--- a/Source/Crypto/BEOpenSSLRSA.cpp
+++ b/Source/Crypto/BEOpenSSLRSA.cpp
@@ -1,0 +1,138 @@
+/*
+ BEOpenSSLRSA.cpp
+ BaseElements Plug-In
+ 
+ Copyright 2018 Goya. All rights reserved.
+ For conditions of distribution and use please see the copyright notice in BEPlugin.cpp
+ 
+ http://www.goya.com.au/baseelements/plugin
+ 
+ */
+
+
+#include "BEOpenSSLRSA.h"
+#include "BEPluginException.h"
+
+
+#include <openssl/ssl.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+
+
+using namespace std;
+using namespace fmx;
+
+
+static const EVP_MD * getDigestByName ( const string &digestName ) {
+	const EVP_MD * digest;
+	if ( digestName.empty() ) {
+		digest = EVP_sha256();
+	} else {
+		OpenSSL_add_all_algorithms();
+		digest = EVP_get_digestbyname ( digestName.data() );
+		if ( !digest ) {
+			throw BEPlugin_Exception ( kRSATranslateDigestFailed );
+		}
+	}
+	return digest;
+}
+
+static int passwordCallback(char *buf, int max_len, int /* flag */, void *ctx)
+{
+	string &s = * static_cast<string *>(ctx);
+	if ( s.length() > (size_t)max_len ) {
+		return 0;
+	}
+	copy ( s.begin(), s.end(), buf ) ;
+	return (int)s.length();
+}
+
+const vector<char> SignatureGenerate_RSA ( const vector<unsigned char> data, const string privateKey, const string digestName, string privateKeyPassword )
+{
+	unique_ptr<BIO, decltype(&BIO_free)> priKeyBio ( BIO_new_mem_buf ( privateKey.data(), (int)privateKey.size() ), &BIO_free );
+	if ( !priKeyBio ) {
+		throw BEPlugin_Exception ( kRSALoadBioFailed );
+	}
+
+	// Without this, passwordCallback is not invoked.
+	OpenSSL_add_all_algorithms();
+	unique_ptr<RSA, decltype(&RSA_free)> priKeyRsa ( PEM_read_bio_RSAPrivateKey ( priKeyBio.get(), NULL, passwordCallback, &privateKeyPassword ), &RSA_free );
+	if ( !priKeyRsa ) {
+		throw BEPlugin_Exception ( kRSAReadPrivateKeyFailed );
+	}
+
+	unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx ( EVP_MD_CTX_create(), &EVP_MD_CTX_destroy );
+	unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> evpPkey ( EVP_PKEY_new(), &EVP_PKEY_free );
+
+	if ( EVP_PKEY_set1_RSA( evpPkey.get(), priKeyRsa.get() ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSAReadPrivateKeyFailed );
+	}
+
+	const EVP_MD * digest = getDigestByName ( digestName );
+
+	if ( EVP_SignInit_ex ( ctx.get(), digest, NULL ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSASignInitFailed );
+	}
+
+	if ( EVP_SignUpdate ( ctx.get(), data.data(), data.size() ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSASignUpdateFailed );
+	}
+
+	unsigned int outlen = EVP_PKEY_size ( evpPkey.get() );
+	unique_ptr<unsigned char, decltype(&free)> out ( (unsigned char *)malloc ( outlen ), free );
+	if ( EVP_SignFinal ( ctx.get(), out.get(), &outlen, evpPkey.get() ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSASignFinalFailed );
+	}
+
+	vector<char> result;
+	result.insert ( result.end(), out.get(), out.get() + outlen );
+	return result;
+
+} // SignatureGenerate_RSA
+
+
+const bool SignatureVerify_RSA ( const vector<unsigned char> data, const string publicKey, const vector<char> signature, const string digestName )
+{
+	unique_ptr<BIO, decltype(&BIO_free)> pubKeyBio ( BIO_new_mem_buf ( publicKey.data(), (int)publicKey.size() ), &BIO_free );
+	if ( !pubKeyBio ) {
+		throw BEPlugin_Exception ( kRSALoadBioFailed );
+	}
+
+	unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> evpPkey ( EVP_PKEY_new(), &EVP_PKEY_free );
+	if ( !evpPkey ) {
+		throw BEPlugin_Exception ( kLowMemoryError );
+	}
+
+	// Try to read the public key as PKCS#1
+	unique_ptr<RSA, decltype(&RSA_free)> pkeyPkcs1 ( PEM_read_bio_RSAPublicKey ( pubKeyBio.get(), NULL, NULL, NULL ), &RSA_free );
+	if ( pkeyPkcs1 ) {
+		// It's PKCS#1. Convert it from RSA to EVP_PKEY.
+		if ( EVP_PKEY_set1_RSA ( evpPkey.get(), pkeyPkcs1.get() ) <= 0 ) {
+			throw BEPlugin_Exception ( kRSAReadPublicKeyFailed );
+		}
+	} else {
+		BIO_reset ( pubKeyBio.get() );
+		// Retry as PKCS#8
+		evpPkey = unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> ( PEM_read_bio_PUBKEY ( pubKeyBio.get(), NULL, NULL, NULL ), &EVP_PKEY_free );
+		if ( !evpPkey ) {
+			// The public key is invalid or in unknown format.
+			throw BEPlugin_Exception ( kRSAReadPublicKeyFailed );
+		}
+	}
+
+	unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx ( EVP_MD_CTX_create(), &EVP_MD_CTX_destroy );
+
+	const EVP_MD * digest = getDigestByName ( digestName );
+
+	if ( EVP_VerifyInit_ex ( ctx.get(), digest, NULL ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSAVerifyInitFailed );
+	}
+
+	if ( EVP_VerifyUpdate ( ctx.get(), data.data(), data.size() ) <= 0 ) {
+		throw BEPlugin_Exception ( kRSAVerifyUpdateFailed );
+	}
+
+	return EVP_VerifyFinal ( ctx.get(), (unsigned char *)signature.data(), (unsigned int)signature.size(), evpPkey.get() );
+
+} // SignatureGenerate_RSA
+

--- a/Source/Crypto/BEOpenSSLRSA.h
+++ b/Source/Crypto/BEOpenSSLRSA.h
@@ -1,0 +1,25 @@
+/*
+ BEOpenSSLRSA.h
+ BaseElements Plug-In
+ 
+ Copyright 2018 Goya. All rights reserved.
+ For conditions of distribution and use please see the copyright notice in BEPlugin.cpp
+ 
+ http://www.goya.com.au/baseelements/plugin
+ 
+ */
+
+
+#ifndef __BaseElements__BEOpenSSLRSA__
+#define __BaseElements__BEOpenSSLRSA__
+
+
+#include "BEPluginGlobalDefines.h"
+#include "BEPluginUtilities.h"
+
+
+const std::vector<char> SignatureGenerate_RSA ( const std::vector<unsigned char> data, const std::string privateKey, const std::string digestName, std::string privateKeyPassword );
+const bool SignatureVerify_RSA ( const std::vector<unsigned char> data, const std::string publicKey, const std::vector<char> signature, const std::string digestName );
+
+
+#endif /* defined(__BaseElements__BEOpenSSLRSA__) */


### PR DESCRIPTION
- Attached the function specs at the bottom (slightly changed from the original plan).
- FM test records are included.
- It may be better to report OpenSSL error code, but its type is `unsigned long` while `fmx::errcode` is `short`.

----

## BE\_SignatureGenerate\_RSA

Generates a digital signature of __data__. The message digest of __data__ is calculated first using the specified __algorithm__. Then the digest is encrypted with __privateKey__.

### Parameters

- __data__ : The data to be signed. It can be text or container field.
- __privateKey__ : The private key (as text) to digitally sign the input text.
- __privateKeyPassword__ ( optional ) : The password of the private key. It will be ignored if the private key is not password-protected.
- __algorithm__ ( optional ) : The hash algorithm (as text) to calculate the digest of the data. "SHA256" will be used when it's empty or omitted.
- __fileNameWithExtension__ (optional) : The filename and extension for the generated signature file.

### Result

Container content if __fileNameWithExtension__ is specified. Otherwise, Base64 encoded text.

## BE\_SignatureVerify\_RSA

Verifies if __signature__ is valid for __data__ by comparing the message digest of __data__ with the digest obtained from __signature__ after decrypting it using __publicKey__.

### Parameters

- __data__ : The source data that was signed. It can be text or container field.
- __publicKey__ : The public key (as text) to verify the digital signature. PKCS#1 and PKCS#8 PEM formats are supported.
- __signature__ : The digital signature. It can be container field or Base64 encoded text.
- __algorithm__ ( optional ) : The hash algorithm (as text) to calculate the digest of the data. "SHA256" will be used when it's empty or omitted.

### Result

_1_ if the signature is verified successfully. _0_ otherwise.

