### PR TITLE
Added run_with_popen to BESystemCommand for Mac Linux and iOS BE_Exec…

### DIFF
--- a/Source/BEPluginFunctions.cpp
+++ b/Source/BEPluginFunctions.cpp
@@ -3937,6 +3937,13 @@ fmx::errcode BE_ExecuteSystemCommand ( short /* funcId */, const ExprEnv& /* env
 		const long timeout = ParameterAsLong ( parameters, 1, kBE_Never );
 
 		SystemCommand command;
+        
+#if defined FMX_MAC_TARGET || FMX_LINUX_TARGET || FMX_IOS_TARGET
+        SetResult ( command.run_with_popen( shell_command, timeout ), results );
+#endif
+        
+#if defined FMX_WIN_TARGET
+        
 		Poco::ActiveResult<string> result = command.execute ( shell_command );
 
 		switch ( timeout ) {
@@ -3962,6 +3969,7 @@ fmx::errcode BE_ExecuteSystemCommand ( short /* funcId */, const ExprEnv& /* env
 		if ( result.available() ) {
 			SetResult ( result.data(), results );
 		}
+#endif
 		
 	} catch ( BEPlugin_Exception& e ) {
 		error = e.code();

--- a/Source/BESystemCommand.cpp
+++ b/Source/BESystemCommand.cpp
@@ -33,7 +33,7 @@ std::string SystemCommand::execute_implementation ( const std::string& shell_com
 #else
 		auto command_and_arguments = boost::program_options::split_unix ( shell_command );
 #endif
-		
+        
 		if ( command_and_arguments.size() > 0 ) { // otherwise we return the empty string.
 			
 			auto command = command_and_arguments.front();
@@ -63,3 +63,115 @@ std::string SystemCommand::execute_implementation ( const std::string& shell_com
 	return result;
 
 }
+
+std::string SystemCommand::run_with_popen ( const std::string& shell_command, const long command_timeout ) {
+    
+    std::string result ;
+    std::string bin_sh ;
+    
+    short error = kNoError;
+
+    if (shell_command.length() > 0) {
+
+    
+        FILE * command_result = popen ( shell_command.c_str(), "r" );
+
+        if ( command_result ) {
+
+            short close_error ;
+            char reply[PATH_MAX];
+
+            struct timeval timeout;
+            struct timeval hold ;
+            
+            switch ( command_timeout ) {
+
+                case kBE_Never:
+                case 0:
+                    hold.tv_sec = 0;
+                    hold.tv_usec = 0;
+                    break;
+
+                default:
+                    hold.tv_sec = command_timeout / 1000;
+                    hold.tv_usec = (command_timeout % 1000) * 1000;
+
+            } // switch
+
+            boost::posix_time::ptime start = boost::posix_time::microsec_clock::universal_time();
+
+            fd_set readfd;
+            FD_ZERO ( &readfd );
+
+            while ( true ) {
+
+                if ( (command_timeout) > kBE_Never && ( (boost::posix_time::microsec_clock::universal_time() - start).total_milliseconds() > command_timeout) ) {
+                    error = kCommandTimeout;
+                    break ;
+                }
+
+                FD_SET ( fileno ( command_result ), &readfd );
+
+                int select_response = 0;
+
+                if ( command_timeout > kBE_Never ) {
+                    /* reinitialise timeout in case timeout is changed by select */
+                    timeout.tv_sec = hold.tv_sec ;
+                    timeout.tv_usec = hold.tv_usec ;
+                    select_response = select ( fileno ( command_result ) + 1, &readfd, NULL, NULL, &timeout );
+                } else {
+                    select_response = select ( fileno ( command_result ) + 1, &readfd, NULL, NULL, NULL );
+                }
+
+                if ( select_response < 0 ) {
+                    pclose ( command_result ); // https://github.com/GoyaPtyLtd/BaseElements-Plugin/issues/166
+                    throw BEPlugin_Exception ( errno );
+                } else if ( select_response == 0 ) {
+                    pclose ( command_result ); // https://github.com/GoyaPtyLtd/BaseElements-Plugin/issues/166
+                    throw BEPlugin_Exception ( kCommandTimeout ); // timeout
+                } else {
+
+                    if ( FD_ISSET ( fileno ( command_result ), &readfd ) ) {
+
+                        if ( fgets ( reply, sizeof ( reply ), command_result ) != NULL ) {
+                            result.append ( reply );
+                        } else {
+                            // nothing returned by the command
+                            break;
+                        }
+                    } else {
+                        //   error = errno;
+                        break;
+                    }
+
+                } // if ( select_response < 0 )
+
+            } // while
+
+            close_error = pclose ( command_result );
+            if ( error == kNoError ) { // don't overwrite an earlier error
+
+                if ( WIFEXITED ( close_error ) ) {
+                    error = WEXITSTATUS ( close_error );
+                } else {
+                    error = close_error;
+                }
+
+            } else if ( error == 13 ) { // report an error on command timeout
+                error = kCommandTimeout;
+            }
+
+        } else {
+            error = errno;
+        }
+        
+        if( error != kNoError ) {
+            throw BEPlugin_Exception ( error ) ;
+        }
+        
+    } // if shell_command.length() > 0
+    
+    return result ;
+}
+
+

--- a/Source/BESystemCommand.h
+++ b/Source/BESystemCommand.h
@@ -15,22 +15,25 @@
 
 
 #include "BEPluginUtilities.h"
-
+#include <errno.h>
+#include "BEPluginException.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <Poco/ActiveMethod.h>
-
 
 class SystemCommand
 {
 	public:
 	
-		SystemCommand(): execute(this, &SystemCommand::execute_implementation) {}
-	
-		Poco::ActiveMethod<std::string, std::string, SystemCommand> execute;
-	
+    SystemCommand():execute(this, &SystemCommand::execute_implementation) {}
+    
+            Poco::ActiveMethod<std::string, std::string, SystemCommand> execute;
+    
+    std::string run_with_popen( const std::string& shell_command, const long command_timeout = kBE_Never  ) ;
+    
 	protected:
 	
-	std::string execute_implementation ( const std::string& shell_command );// {
-	
+        std::string execute_implementation ( const std::string& shell_command ); //
+    
 };
 
 


### PR DESCRIPTION
…uteSystemCommand [Github #166] [Github #181]

run_with_open is derived from BEShell with calls to pclose when select returns -1 or 0.