### PR TITLE
small fix in documentation example for BE_RegularExpression.md

### DIFF
--- a/docs/Functions/BE_RegularExpression.md
+++ b/docs/Functions/BE_RegularExpression.md
@@ -52,7 +52,7 @@ More examples can be found here : [http://perldoc.perl.org/perlre.html#Regular-E
 	
 To get a list of all the file paths that end in ".fmp12" : 
 
-	BE_ValuesUnique ( BE_RegularExpression ( BE_FileListFolder ( $path ) ; "^.*fmp12$" ; "v" ) )
+	BE_ValuesUnique ( BE_RegularExpression ( BE_FileListFolder ( $path ) ; "^.*\\.fmp12$" ; "v" ) )
 	
 The above example uses *BE_ValuesUnique* because the function leaves empty lines where the criteria doesn't match, so you'd have as many "values" as there were originally files, but anything not matching the criteria would be blank text in the list.
 


### PR DESCRIPTION
The expression currently in the examples would match to files that end with "fmp12" (without a preceding dot). So, for example, "file_with_no_extension_fmp12" would wrongly be in the results.  I added the (escaped) dot to the matching expression so only files that end with ".fmp12" match.