### PR TITLE
Containerised Ubuntu 22.04 ARM GitHub Actions workflow for multi-platform builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ jobs:
           - os: ubuntu-22.04
             arch: x86_64
             platform: ubuntu22.04-x86_64
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            platform: ubuntu22.04-aarch64
           - os: ubuntu-24.04
             arch: x86_64
             platform: ubuntu24.04-x86_64
@@ -61,7 +58,7 @@ jobs:
             clang-tools \
             libclang-dev \
             libclang1 \
-            python3-clang \
+            python3-clang
 
       - name: Install LLVM 18
         run: |
@@ -69,22 +66,15 @@ jobs:
           chmod +x /tmp/llvm.sh
           sudo bash /tmp/llvm.sh 18
           rm -f /tmp/llvm.sh
-          echo "Checking installed LLVM 18 binaries..."
-          ls -la /usr/bin/llvm-config-18 2>/dev/null && echo "llvm-config-18 found" || echo "llvm-config-18 NOT found"
-          ls -la /usr/bin/clang-18 2>/dev/null && echo "clang-18 found" || echo "clang-18 NOT found"
 
       - name: Configure clang alternatives
         run: |
           VERSION=18
           PRIORITY=100
-          # Remove existing alternatives if they exist (from base packages)
           sudo update-alternatives --remove-all clang++ 2>/dev/null || true
           sudo update-alternatives --remove-all clang 2>/dev/null || true
           sudo update-alternatives --remove-all llvm-config 2>/dev/null || true
-          
-          # Check if LLVM 18 binaries exist before configuring alternatives
           if [[ -f /usr/bin/llvm-config-${VERSION} ]] && [[ -f /usr/bin/clang-${VERSION} ]]; then
-            echo "Configuring alternatives for LLVM ${VERSION}..."
             sudo update-alternatives \
               --install /usr/bin/llvm-config       llvm-config      /usr/bin/llvm-config-${VERSION} ${PRIORITY} \
               --slave   /usr/bin/llvm-ar           llvm-ar          /usr/bin/llvm-ar-${VERSION} \
@@ -114,38 +104,8 @@ jobs:
               --slave   /usr/bin/lldb                  lldb                  /usr/bin/lldb-${VERSION} \
               --slave   /usr/bin/lldb-server           lldb-server           /usr/bin/lldb-server-${VERSION}
           else
-            echo "Warning: LLVM ${VERSION} binaries not found. Checking available versions..."
-            ls -la /usr/bin/llvm-config-* 2>/dev/null || echo "No llvm-config versions found"
-            ls -la /usr/bin/clang-* 2>/dev/null | head -5 || echo "No clang versions found"
-            echo "Falling back to system defaults."
+            echo "LLVM ${VERSION} not found, using system defaults."
           fi
-
-      - name: Debug - Show LLVM and Clang versions
-        run: |
-          echo "=========================================="
-          echo "LLVM and Clang Version Information"
-          echo "=========================================="
-          echo ""
-          echo "=== Clang Version ==="
-          clang --version || echo "clang not found"
-          echo ""
-          echo "=== Clang++ Version ==="
-          clang++ --version || echo "clang++ not found"
-          echo ""
-          echo "=== LLVM Config Version ==="
-          llvm-config --version || echo "llvm-config not found"
-          echo ""
-          echo "=== Which binaries are being used ==="
-          which clang || echo "clang not in PATH"
-          which clang++ || echo "clang++ not in PATH"
-          which llvm-config || echo "llvm-config not in PATH"
-          echo ""
-          echo "=== Real paths (resolving symlinks) ==="
-          readlink -f $(which clang 2>/dev/null) || echo "clang not found"
-          readlink -f $(which clang++ 2>/dev/null) || echo "clang++ not found"
-          readlink -f $(which llvm-config 2>/dev/null) || echo "llvm-config not found"
-          echo ""
-          echo "=========================================="
 
       - name: Download external libraries
         env:
@@ -167,7 +127,7 @@ jobs:
           mkdir -p build
           cd build
           cmake -DCMAKE_BUILD_TYPE=Release ..
-          make -j$(nproc)
+          make -j"$(nproc)"
 
       - name: Collect build outputs
         run: |
@@ -181,8 +141,142 @@ jobs:
           path: BaseElements-${{ matrix.platform }}.fmx
           retention-days: 30
 
+  build-arm-22:
+    # Problem child: ubuntu22.04-aarch64, built in a controlled ARM container
+    runs-on: ubuntu-22.04-arm
+    container:
+      image: ubuntu:22.04
+    defaults:
+      run:
+        shell: bash
+    env:
+      PLATFORM: ubuntu22.04-aarch64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies inside container
+        run: |
+          apt-get update
+          apt-get install -y \
+            curl sudo lsb-release wget software-properties-common gnupg binutils \
+            build-essential \
+            zip \
+            unzip \
+            wget \
+            gperf \
+            cmake \
+            git \
+            git-lfs \
+            libexpat1-dev \
+            lld \
+            lldb \
+            liblldb-dev \
+            libomp5 \
+            libomp-dev \
+            llvm \
+            llvm-dev \
+            llvm-runtime \
+            clang \
+            clangd \
+            clang-format \
+            clang-tidy \
+            clang-tools \
+            libclang-dev \
+            libclang1 \
+            python3-clang
+
+          echo "=== libstdc++ symbols in container ==="
+          strings /usr/lib/aarch64-linux-gnu/libstdc++.so.6 | grep GLIBCXX_ | sort -V | tail -10 || true
+
+      - name: Download external libraries
+        run: |
+          set -euo pipefail
+          mkdir -p external
+          cd external
+          URL="https://github.com/DanSmith888/BaseElements-Plugin-Libraries/releases/download/v0.1.0/external-${PLATFORM}.tar.gz"
+          echo "Fetching external libraries from ${URL}"
+          curl -sSL -o external.tar.gz "${URL}"
+          tar -xzf external.tar.gz
+
+      - name: Install LLVM 18
+        run: |
+          wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo bash /tmp/llvm.sh 18
+          rm -f /tmp/llvm.sh
+
+      - name: Configure clang alternatives
+        run: |
+          VERSION=18
+          PRIORITY=100
+          sudo update-alternatives --remove-all clang++ 2>/dev/null || true
+          sudo update-alternatives --remove-all clang 2>/dev/null || true
+          sudo update-alternatives --remove-all llvm-config 2>/dev/null || true
+          if [[ -f /usr/bin/llvm-config-${VERSION} ]] && [[ -f /usr/bin/clang-${VERSION} ]]; then
+            sudo update-alternatives \
+              --install /usr/bin/llvm-config       llvm-config      /usr/bin/llvm-config-${VERSION} ${PRIORITY} \
+              --slave   /usr/bin/llvm-ar           llvm-ar          /usr/bin/llvm-ar-${VERSION} \
+              --slave   /usr/bin/llvm-as           llvm-as          /usr/bin/llvm-as-${VERSION} \
+              --slave   /usr/bin/llvm-bcanalyzer   llvm-bcanalyzer  /usr/bin/llvm-bcanalyzer-${VERSION} \
+              --slave   /usr/bin/llvm-cov          llvm-cov         /usr/bin/llvm-cov-${VERSION} \
+              --slave   /usr/bin/llvm-diff         llvm-diff        /usr/bin/llvm-diff-${VERSION} \
+              --slave   /usr/bin/llvm-dis          llvm-dis         /usr/bin/llvm-dis-${VERSION} \
+              --slave   /usr/bin/llvm-dwarfdump    llvm-dwarfdump   /usr/bin/llvm-dwarfdump-${VERSION} \
+              --slave   /usr/bin/llvm-extract      llvm-extract     /usr/bin/llvm-extract-${VERSION} \
+              --slave   /usr/bin/llvm-link         llvm-link        /usr/bin/llvm-link-${VERSION} \
+              --slave   /usr/bin/llvm-mc           llvm-mc          /usr/bin/llvm-mc-${VERSION} \
+              --slave   /usr/bin/llvm-nm           llvm-nm          /usr/bin/llvm-nm-${VERSION} \
+              --slave   /usr/bin/llvm-objdump      llvm-objdump     /usr/bin/llvm-objdump-${VERSION} \
+              --slave   /usr/bin/llvm-ranlib       llvm-ranlib      /usr/bin/llvm-ranlib-${VERSION} \
+              --slave   /usr/bin/llvm-readobj      llvm-readobj     /usr/bin/llvm-readobj-${VERSION} \
+              --slave   /usr/bin/llvm-rtdyld       llvm-rtdyld      /usr/bin/llvm-rtdyld-${VERSION} \
+              --slave   /usr/bin/llvm-size         llvm-size        /usr/bin/llvm-size-${VERSION} \
+              --slave   /usr/bin/llvm-stress       llvm-stress      /usr/bin/llvm-stress-${VERSION} \
+              --slave   /usr/bin/llvm-symbolizer   llvm-symbolizer  /usr/bin/llvm-symbolizer-${VERSION} \
+              --slave   /usr/bin/llvm-tblgen       llvm-tblgen      /usr/bin/llvm-tblgen-${VERSION}
+            sudo update-alternatives \
+              --install /usr/bin/clang                 clang                 /usr/bin/clang-${VERSION} ${PRIORITY} \
+              --slave   /usr/bin/clang++               clang++               /usr/bin/clang++-${VERSION}  \
+              --slave   /usr/bin/asan_symbolize        asan_symbolize        /usr/bin/asan_symbolize-${VERSION} \
+              --slave   /usr/bin/clang-cpp             clang-cpp             /usr/bin/clang-cpp-${VERSION} \
+              --slave   /usr/bin/lldb                  lldb                  /usr/bin/lldb-${VERSION} \
+              --slave   /usr/bin/lldb-server           lldb-server           /usr/bin/lldb-server-${VERSION}
+          else
+            echo "LLVM ${VERSION} not found, using system defaults."
+          fi
+
+      - name: Configure and build (ARM container)
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          mkdir -p build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make -j"$(nproc)"
+
+      - name: Check GLIBCXX usage in plugin
+        run: |
+          objdump -T build/BaseElements.fmx | grep GLIBCXX_ | sort -V | tail -10 || true
+
+      - name: Collect build outputs
+        run: |
+          set -euo pipefail
+          cp "build/BaseElements.fmx" "BaseElements-${PLATFORM}.fmx"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaseElements-${{ env.PLATFORM }}
+          path: BaseElements-${{ env.PLATFORM }}.fmx
+          retention-days: 30
+
   release:
-    needs: build
+    needs:
+      - build
+      - build-arm-22
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -198,4 +292,3 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,4 +397,3 @@ install(
 
 # Set correct file ownership after installation
 install(CODE "execute_process(COMMAND chown -f \"${INSTALL_OWNER}\" \"${CMAKE_INSTALL_PREFIX}/BaseElements.fmx\" COMMAND_ECHO STDOUT)")
-


### PR DESCRIPTION
All four platforms built the plugin cleanly in GitHub Actions, but when I loaded them onto fms to test, the Ubuntu 22.04 ARM version failed to load. That sent me down a rabbit hole of ABI differences between the GitHub runners and standard ubuntu.

The ARM GitHub runner for Ubuntu 22.04 is using a newer libstdc++ than ubuntu22.04's standard version. The runner produced a plugin that referenced GLIBCXX_3.4.32, but normal ubuntu 22.04 only supports up to GLIBCXX_3.4.30. So the fms plugin loader  rejects it. The x86 builds didn’t hit this problem because the x86 runners (which are direct from github, not partner images) use a standard version of libstdc++.

I've found a solution; an ARM runner that provisions an Ubuntu 22.04 ARM docker container, allows me to setup the container the same as the README steps and then build the plugin inside the container.  This gives us a compatible libstdc++ that matches regualr Ubuntu 22.04's ABI. If I had only done this for the library repo builds it would have been a lot easier and avoided all the pre-installed package issues.
