### PR TITLE
Ubuntu build + CI cleanup (U22/U24, x64/arm64)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Manual run (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -216,7 +216,7 @@ jobs:
           cp "build/BaseElements.fmx" "BaseElements-${{ matrix.platform }}.fmx"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: BaseElements-${{ matrix.platform }}
           path: BaseElements-${{ matrix.platform }}.fmx
@@ -228,7 +228,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Manual run (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -195,9 +195,9 @@ jobs:
           set -euo pipefail
           mkdir -p external
           cd external
-          URL="https://github.com/GoyaPtyLtd/BaseElements-Plugin-Libraries/releases/tag/v5.1.0.1/external-${PACKAGE_PLATFORM}.tar.gz"
+          URL="https://github.com/GoyaPtyLtd/BaseElements-Plugin-Libraries/releases/download/v5.1.0.1/external-${PACKAGE_PLATFORM}.tar.gz"
           echo "Fetching external libraries from ${URL}"
-          curl -sSL -o external.tar.gz "${URL}"
+          curl -fsSL -o external.tar.gz "${URL}"
           tar -xzf external.tar.gz
 
       - name: Configure and build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,17 @@
-name: Build Plugin
+name: Build and Release Plugin
 
 on:
   push:
     tags:
       - 'v*'
+  # Lets you run from the GitHub UI: Actions → this workflow → "Run workflow"
   workflow_dispatch:
-
-env:
-  BUILD_TYPE: Debug
+    inputs:
+      note:
+        description: Optional note for this run (logged in the job; leave blank if you like)
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build:
@@ -20,10 +24,28 @@ jobs:
             arch: x86_64
             platform: ubuntu22.04-x86_64
             package_platform: ubuntu22.04-x86_64
+          - runner: ubuntu-22.04-arm
+            arch: aarch64
+            platform: ubuntu22.04-aarch64
+            package_platform: ubuntu22.04-aarch64
+          - runner: ubuntu-24.04
+            arch: x86_64
+            platform: ubuntu24.04-x86_64
+            package_platform: ubuntu24.04-x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+            platform: ubuntu24.04-aarch64
+            package_platform: ubuntu24.04-aarch64
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Manual run (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Triggered manually from the Actions tab."
+          echo "Optional note: ${{ github.event.inputs.note }}"
 
       - name: Install build dependencies (Ubuntu)
         if: startsWith(matrix.runner, 'ubuntu')
@@ -34,6 +56,7 @@ jobs:
             zip \
             unzip \
             wget \
+            curl \
             gperf \
             cmake \
             git \
@@ -121,6 +144,34 @@ jobs:
       - name: Debug - Show LLVM and Clang versions (Ubuntu)
         if: startsWith(matrix.runner, 'ubuntu')
         run: |
+            echo "=========================================="
+            echo "LLVM and Clang Version Information"
+            echo "=========================================="
+            echo ""
+            echo "=== Clang Version ==="
+            clang --version || echo "clang not found"
+            echo ""
+            echo "=== Clang++ Version ==="
+            clang++ --version || echo "clang++ not found"
+            echo ""
+            echo "=== LLVM Config Version ==="
+            llvm-config --version || echo "llvm-config not found"
+            echo ""
+            echo "=== Which binaries are being used ==="
+            which clang || echo "clang not in PATH"
+            which clang++ || echo "clang++ not in PATH"
+            which llvm-config || echo "llvm-config not in PATH"
+            echo ""
+            echo "=== Real paths (resolving symlinks) ==="
+            readlink -f $(which clang 2>/dev/null) || echo "clang not found"
+            readlink -f $(which clang++ 2>/dev/null) || echo "clang++ not found"
+            readlink -f $(which llvm-config 2>/dev/null) || echo "llvm-config not found"
+            echo ""
+            echo "=========================================="
+
+      - name: Debug - Show LLVM and Clang versions (macOS)
+        if: startsWith(matrix.runner, 'macos')
+        run: |
           echo "=========================================="
           echo "LLVM and Clang Version Information"
           echo "=========================================="
@@ -131,28 +182,67 @@ jobs:
           echo "=== Clang++ Version ==="
           clang++ --version || echo "clang++ not found"
           echo ""
-          echo "=== LLVM Config Version ==="
-          llvm-config --version || echo "llvm-config not found"
-          echo ""
           echo "=== Which binaries are being used ==="
           which clang || echo "clang not in PATH"
           which clang++ || echo "clang++ not in PATH"
-          which llvm-config || echo "llvm-config not in PATH"
-          echo ""
-          echo "=== Real paths (resolving symlinks) ==="
-          readlink -f $(which clang 2>/dev/null) || echo "clang not found"
-          readlink -f $(which clang++ 2>/dev/null) || echo "clang++ not found"
-          readlink -f $(which llvm-config 2>/dev/null) || echo "llvm-config not found"
           echo ""
           echo "=========================================="
 
-      - name: Create Build folder
+      - name: Download external libraries
+        env:
+          PACKAGE_PLATFORM: ${{ matrix.package_platform }}
+        run: |         
+          set -euo pipefail
+          mkdir -p external
+          cd external
+          URL="https://github.com/GoyaPtyLtd/BaseElements-Plugin-Libraries/releases/tag/v5.1.0.1/external-${PACKAGE_PLATFORM}.tar.gz"
+          echo "Fetching external libraries from ${URL}"
+          curl -sSL -o external.tar.gz "${URL}"
+          tar -xzf external.tar.gz
+
+      - name: Configure and build
+        env:
+          CC: clang
+          CXX: clang++
         run: |
-          mkdir build
+          mkdir -p build
           cd build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          make -j"$(nproc)"
+  
+      - name: Collect build outputs
+        run: |
+          set -euo pipefail
+          cp "build/BaseElements.fmx" "BaseElements-${{ matrix.platform }}.fmx"
 
-      - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaseElements-${{ matrix.platform }}
+          path: BaseElements-${{ matrix.platform }}.fmx
+          retention-days: 30
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: List downloaded artifacts
+        run: |
+          echo "Artifacts downloaded:"
+          find artifacts -type f -name "*.fmx" || echo "No artifacts found"
+          ls -la artifacts/ || true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,12 @@ Project/core
 Project/CodeSigning/*
 *.vsidx
 *.lock
+
+/PlugInSDK/
+
+# Ignore build products
+/build*/
+
+# Ignore external libraries
+/external/*
+!/external/README.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,19 +49,46 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "${DEFAULT_INSTALL_PREFIX}")
 endif()
 
-# FileMaker Plugin SDK target
-include(ExternalProject)
-ExternalProject_Add(
-    fm_plugin_sdk
-    PREFIX "${CMAKE_BINARY_DIR}/fm_plugin_sdk"  # Download here
-    SOURCE_DIR "${CMAKE_SOURCE_DIR}/PlugInSDK"  # Unpack contents here
-    # See: https://www.claris.com/resources/downloads/
-    URL https://downloads.claris.com/DEVREL/sdk/fm_plugin_sdk_21.0.1.53.zip
-    URL_HASH SHA256=422017d7952668addaa4e212e327eadc88ffbd2318abceae22382ce3458c38d5
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
+# Platform detection for external/* layout and Linux arch-specific paths
+execute_process(
+    COMMAND uname -m
+    OUTPUT_VARIABLE NATIVE_ARCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+if(NATIVE_ARCH MATCHES "aarch64|arm64")
+    set(TARGET_ARCH                    "aarch64")
+    set(TARGET_ARCH_DIR                "arm64")
+    set(TARGET_LIB_DIR                 "aarch64-linux-gnu")
+    set(ARCH_FLAG                      "")
+else()
+    set(TARGET_ARCH                    "x86_64")
+    set(TARGET_ARCH_DIR                "x64")
+    set(TARGET_LIB_DIR                 "x86_64-linux-gnu")
+    set(ARCH_FLAG                      "-m64")
+endif()
+
+execute_process(
+    COMMAND sh -c "lsb_release -rs 2>/dev/null || (grep VERSION_ID /etc/os-release | tr -d '\"' | cut -d= -f2)"
+    OUTPUT_VARIABLE UBUNTU_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+
+if(UBUNTU_VERSION MATCHES "^22")
+    set(UBUNTU_SDK_DIR                 "U22")
+    set(LEGACY_UBUNTU_LIB_DIR          "ubuntu22")
+elseif(UBUNTU_VERSION MATCHES "^24")
+    set(UBUNTU_SDK_DIR                 "U24")
+    set(LEGACY_UBUNTU_LIB_DIR          "ubuntu24")
+else()
+    set(UBUNTU_SDK_DIR                 "U24")
+    set(LEGACY_UBUNTU_LIB_DIR          "ubuntu24")
+endif()
+
+set(PLATFORM_DIR                       "ubuntu${UBUNTU_VERSION}-${TARGET_ARCH}")
+set(EXTERNAL_PLATFORM_DIR              "${CMAKE_SOURCE_DIR}/external/${PLATFORM_DIR}")
+set(DUKTAPE_SOURCE_FILE                "${EXTERNAL_PLATFORM_DIR}/src/duktape/duktape.c")
 
 # BaseElements plugin library/module target
 add_library(
@@ -105,7 +132,7 @@ add_library(
     Source/Net/BESMTP.cpp
     Source/Net/BESMTPContainerAttachments.cpp
     Source/Net/BESMTPEmailMessage.cpp
-    Source/duktape/duktape.c
+    ${DUKTAPE_SOURCE_FILE}
     Source/linux/BELinuxFunctions.cpp
 )
 
@@ -117,24 +144,24 @@ set_target_properties(
 
 target_include_directories(
     BaseElements PUBLIC
-
     Source
-    Headers/FMWrapper
-    Headers
-    Headers/ImageMagick-7
+    "${EXTERNAL_PLATFORM_DIR}/PlugInSDK/Headers"
+    "${EXTERNAL_PLATFORM_DIR}/include/ImageMagick-7"
+    "${EXTERNAL_PLATFORM_DIR}/include"
+    "${EXTERNAL_PLATFORM_DIR}/lib"
+    "${EXTERNAL_PLATFORM_DIR}/src"
 )
 
 target_link_directories(
     BaseElements PUBLIC
-
-    PlugInSDK/Libraries/Linux/U22/x64
-    Libraries/ubuntu22/x86_64
+    "${EXTERNAL_PLATFORM_DIR}/PlugInSDK/Libraries/Linux/${UBUNTU_SDK_DIR}/${TARGET_ARCH_DIR}"
+    "${EXTERNAL_PLATFORM_DIR}/lib"
 )
 
 add_library(libuuid SHARED IMPORTED)
 set_target_properties(
     libuuid PROPERTIES
-        IMPORTED_LOCATION /usr/lib/x86_64-linux-gnu/libuuid.so.1)
+        IMPORTED_LOCATION /usr/lib/${TARGET_LIB_DIR}/libuuid.so.1)
 
 target_link_libraries(
     BaseElements PUBLIC
@@ -153,8 +180,6 @@ target_link_libraries(
     curl
     PocoNet
     ssh2
-    ssl
-    crypto
     xslt
     exslt
     xml2
@@ -163,8 +188,8 @@ target_link_libraries(
     PocoZip
     PocoXML
     podofo
-    podofo_3rdparty
     podofo_private
+    podofo_3rdparty
     unistring
     fontconfig
     freetype
@@ -175,10 +200,11 @@ target_link_libraries(
     png16
     z
     jq
-    openjp2
     PocoUtil
     PocoCrypto
     PocoFoundation
+    ssl
+    crypto
     charset
     expat
     libuuid
@@ -186,9 +212,6 @@ target_link_libraries(
     pthread
     m
 )
-
-# Make BaseElements target dependent upon fm_plugin_sdk target
-add_dependencies(BaseElements fm_plugin_sdk)
 
 # Install target
 install(

--- a/Source/BEPlugin.cpp
+++ b/Source/BEPlugin.cpp
@@ -172,9 +172,9 @@ static FMX_Int32 LoadPlugin ( FMX_ExternCallPtr plugin_call )
 	g_be_plugin->RegisterFunction ( kBE_FileCopy, BE_FileCopy, 2, 3 );
 	g_be_plugin->RegisterFunction ( kBE_FileListFolder, BE_FileListFolder, 1, 5 );
 
-	g_be_plugin->RegisterFunction ( kBE_FileTypeAll + kBE_FileTypeOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_FileTypeFile + kBE_FileTypeOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_FileTypeFolder + kBE_FileTypeOffset, BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_FileTypeAll) + static_cast<short>(kBE_FileTypeOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_FileTypeFile) + static_cast<short>(kBE_FileTypeOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_FileTypeFolder) + static_cast<short>(kBE_FileTypeOffset)), BE_NumericConstants );
 
 #ifdef BEP_PRO_VERSION
 	g_be_plugin->RegisterFunction ( kBE_XSLT_Apply, BE_XSLT_Apply, 3, -1 );
@@ -195,9 +195,9 @@ static FMX_Int32 LoadPlugin ( FMX_ExternCallPtr plugin_call )
 
 	g_be_plugin->RegisterFunction ( kBE_TextExtractWords, BE_TextExtractWords, 1, 2 );
 
-	g_be_plugin->RegisterFunction ( kBE_ButtonOK + kBE_ButtonOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_ButtonCancel + kBE_ButtonOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_ButtonAlternate + kBE_ButtonOffset, BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_ButtonOK) + static_cast<short>(kBE_ButtonOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_ButtonCancel) + static_cast<short>(kBE_ButtonOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_ButtonAlternate) + static_cast<short>(kBE_ButtonOffset)), BE_NumericConstants );
 
 #if ( FMX_MAC_TARGET || FMX_WIN_TARGET || FMX_LINUX_TARGET )
 	g_be_plugin->RegisterFunction ( kBE_ExecuteSystemCommand, BE_ExecuteSystemCommand, 1, 3 );
@@ -273,19 +273,19 @@ static FMX_Int32 LoadPlugin ( FMX_ExternCallPtr plugin_call )
 	g_be_plugin->RegisterFunction ( kBE_HTTP_PATCH, BE_HTTP_POST_PUT_PATCH, 2, 4 );
 
 	g_be_plugin->RegisterFunction ( kBE_MessageDigest, BE_MessageDigest, 1, 3 );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmMD5 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA256 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmMDC2 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA1 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA224 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA384 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_MessageDigestAlgorithmSHA512 + kBE_MessageDigestAlgorithmOffset, BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmMD5) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA256) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmMDC2) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA1) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA224) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA384) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_MessageDigestAlgorithmSHA512) + static_cast<short>(kBE_MessageDigestAlgorithmOffset)), BE_NumericConstants );
 
 	g_be_plugin->RegisterFunction ( kBE_DebugInformation, BE_DebugInformation );
 
-	g_be_plugin->RegisterFunction ( kBE_EncodingHex + kBE_EncodingOffset, BE_NumericConstants );
-	g_be_plugin->RegisterFunction ( kBE_EncodingBase64 + kBE_EncodingOffset, BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_EncodingHex) + static_cast<short>(kBE_EncodingOffset)), BE_NumericConstants );
+	g_be_plugin->RegisterFunction ( static_cast<short>(static_cast<short>(kBE_EncodingBase64) + static_cast<short>(kBE_EncodingOffset)), BE_NumericConstants );
 
 	g_be_plugin->RegisterFunction ( kBE_TimeCurrentMilliseconds, BE_TimeFunctions );
 	g_be_plugin->RegisterFunction ( kBE_TimeUTCMilliseconds, BE_TimeFunctions );

--- a/Source/BEPluginFunctions.cpp
+++ b/Source/BEPluginFunctions.cpp
@@ -57,6 +57,7 @@
 #include <../Headers/iconv/iconv.h>
 
 #include "BEPluginFunctions.h"
+#include "BEPluginUtilities.h"
 
 #include "Net/BECurl.h"
 #include "Net/BECurlOption.h"
@@ -768,8 +769,7 @@ fmx::errcode BE_ExportFieldContents ( short /* funcId */, const ExprEnv& /* envi
 			destination = ParameterAsPath ( parameters, 1 );
 		} else {
 			// write out a temporary file
-			const filesystem::path temporary_file_name = tmpnam ( NULL );  // std::filesystem::unique_path() does yet not exist
-			destination = std::filesystem::temp_directory_path() / temporary_file_name;
+			destination = TemporaryFilePath();
 		}
 
 		error = write_to_file ( destination, field_contents );

--- a/Source/BEPluginUtilities.cpp
+++ b/Source/BEPluginUtilities.cpp
@@ -56,6 +56,13 @@
 #include <filesystem>
 #include <fstream>
 #include <sstream>
+#include <cerrno>
+
+#if defined FMX_WIN_TARGET
+	#include <stdlib.h>
+#else
+	#include <unistd.h>
+#endif
 
 
 using namespace fmx;
@@ -267,9 +274,7 @@ void SetResult ( const string& filename, const vector<unsigned char>& data, fmx:
 void SetResult ( const string& filename, PoDoFo::PdfMemDocument& pdf, fmx::Data& results )
 {
 	// write out a temporary file
-	// std::filesystem::unique_path() does not (yet) exist
-	const filesystem::path temporary_file_name = tmpnam ( NULL );
-	auto temporary_file = std::filesystem::temp_directory_path() / temporary_file_name;
+	auto temporary_file = TemporaryFilePath();
 	pdf.Save ( temporary_file.c_str() );
 	auto file_data = ReadFileAsBinary ( temporary_file );
 	
@@ -778,6 +783,33 @@ string ReadFileAsUTF8 ( const filesystem::path path )
 	return result;
 
 } // ReadFileAsUTF8
+
+
+filesystem::path TemporaryFilePath ( const string& filename_template )
+{
+	const auto temporary_directory = filesystem::temp_directory_path();
+
+#if defined FMX_WIN_TARGET
+	vector<char> path_template ( filename_template.begin(), filename_template.end() );
+	path_template.push_back ( '\0' );
+	if ( _mktemp_s ( path_template.data(), path_template.size() ) != 0 ) {
+		throw BEPlugin_Exception ( errno );
+	}
+
+	return temporary_directory / path_template.data();
+#else
+	auto template_path = ( temporary_directory / filename_template ).string();
+	vector<char> path_template ( template_path.begin(), template_path.end() );
+	path_template.push_back ( '\0' );
+	const int temporary_file = mkstemp ( path_template.data() );
+	if ( temporary_file == -1 ) {
+		throw BEPlugin_Exception ( errno );
+	}
+
+	close ( temporary_file );
+	return path_template.data();
+#endif
+}
 
 
 #pragma mark -

--- a/Source/BEPluginUtilities.h
+++ b/Source/BEPluginUtilities.h
@@ -95,6 +95,7 @@ const bool StreamIsCompressed ( const fmx::BinaryData& data );
 
 const std::vector<char> ReadFileAsBinary ( const std::filesystem::path path );
 std::string ReadFileAsUTF8 ( const std::filesystem::path path );
+std::filesystem::path TemporaryFilePath ( const std::string& filename_template = "beplugin-XXXXXX.tmp" );
 
 std::vector<char> ConvertTextEncoding ( char * in, const size_t length, const std::string& to, const std::string& from = g_text_encoding );
 std::string ConvertTextEncoding ( std::string& in, const std::string& to, const std::string& from = g_text_encoding );

--- a/Source/Crypto/BEOpenSSLAES.cpp
+++ b/Source/Crypto/BEOpenSSLAES.cpp
@@ -29,7 +29,11 @@ using namespace std;
   https://boringssl.googlesource.com/boringssl/+/517073cd4b/crypto/cpu-intel.c#76
  
  */
-uint32_t OPENSSL_ia32cap_P[4] = { 0 };
+// iOS-only fallback for environments where this OpenSSL CPU-capability symbol is missing.
+// Keep this off Linux to avoid duplicate symbol conflicts with libcrypto.a on x86_64.
+#if FMX_IOS_TARGET
+ uint32_t OPENSSL_ia32cap_P[4] = { 0 };
+ #endif
 
 const vector<unsigned char> HexOrContainer ( const fmx::DataVect& parameters, const fmx::uint32 which )
 {

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,8 @@
+# External prebuilt libraries
+
+This directory holds platform-specific headers and static/shared libraries produced by the [BaseElements-Plugin-Libraries](https://github.com/GoyaPtyLtd/BaseElements-Plugin-Libraries) build (or matching release tarballs).
+
+- **Local builds:** extract an `external-<platform>.tar.gz` here so you have `external/ubuntu22.04-x86_64/` (or your platform) with `include/`, `lib/`, `PlugInSDK/`, `src/`, etc.
+- **Git:** everything under `external/` except this file is listed in `.gitignore` so large binaries are not committed.
+
+See the project `CMakeLists.txt` and `.github/workflows/main.yml` for how `external/${PLATFORM_DIR}` is used on Linux.


### PR DESCRIPTION
This PR consolidates minimal impact work to get the plugin building cleanly on Ubuntu in both GitHub runners and local server environments.

I have a working build run [here](https://github.com/DanSmith888/BaseElements-Plugin/actions/runs/24332194864):

- Updated build/runner setup for Ubuntu 22.04 + 24.04 on both x64 and arm64.
- Wrote a new CmakeList.txt for Ubuntu
- Switched to pulling the latest libraries from the tagged Goya release.
- Fixed 16 compiler/linker warnings and deprecations showing up in current toolchains.
- Updated CI actions to clear Node/runtime deprecation stuff.
- Kept changes intentionally small and low-risk, focused on getting builds working and not breaking Nick's working macOS stuff.

Not yet done:
- **Haven’t run-tested the plugin in FileMaker yet.**
- I had a bit of AI help with the C changes, so it would be great to get a knowledgeable human to actually review them
- Nick should do a macOS compile pass to confirm cross-platform is still good.