### PR TITLE
Fix parameter-name and signature typos across 10 function doc pages

### DIFF
--- a/docs/Functions/BE_Encrypt_AES.md
+++ b/docs/Functions/BE_Encrypt_AES.md
@@ -1,6 +1,6 @@
-## BE_Decrypt_AES
+## BE_Encrypt_AES
 
-    BE_Decrypt_AES ( key ; text )
+        BE_Encrypt_AES ( key ; text )
 
 **Description**  
 

--- a/docs/Functions/BE_FileSelectDialog.md
+++ b/docs/Functions/BE_FileSelectDialog.md
@@ -11,7 +11,7 @@ Result is the path to the file selected by the user.  Returns an empty string wh
 **Parameters**
 
 * *prompt* : The text to display in the dialog.
-* *nainFolderPathme* ( optional ) : The folder to start in when opening the dialog. Defaults to the last used folder as determined by the operating system.
+* *inFolderPath* ( optional ) : The folder to start in when opening the dialog. Defaults to the last used folder as determined by the operating system.
 
 **Keywords**  
 

--- a/docs/Functions/BE_FolderSelectDialog.md
+++ b/docs/Functions/BE_FolderSelectDialog.md
@@ -11,7 +11,7 @@ Result is the path to the folder selected by the user.  Returns an empty string 
 **Parameters**
 
 * *prompt* : The text to display in the dialog.
-* *nainFolderPathme* ( optional ) : The folder to start in when opening the dialog. Defaults to the last used folder as determined by the operating system.
+* *inFolderPath* ( optional ) : The folder to start in when opening the dialog. Defaults to the last used folder as determined by the operating system.
 
 **Keywords**  
 

--- a/docs/Functions/BE_HTTP_GET.md
+++ b/docs/Functions/BE_HTTP_GET.md
@@ -9,7 +9,7 @@ Does a http, https, ftp, ftps, or sftp GET / download and returns the results.  
 **Parameters**
 
 * *url* : The url to retrieve.
-* *username* ( optional ) : The username if the url requires authentication.
+* *filename* ( optional ) : The path to save the file to.
 * *username* ( optional ) : The username if the url requires authentication.
 * *password* ( optional ) : The password if the url requires authentication.
 

--- a/docs/Functions/BE_HTTP_GET_File.md
+++ b/docs/Functions/BE_HTTP_GET_File.md
@@ -1,6 +1,6 @@
-## BE_HTTP_GET
+## BE_HTTP_GET_File
 
-    BE_HTTP_GET ( url ; { path ; username ; password } )
+        BE_HTTP_GET_File ( url ; { path ; username ; password } )
 
 **Description**  
 

--- a/docs/Functions/BE_HTTP_PUTFile.md
+++ b/docs/Functions/BE_HTTP_PUTFile.md
@@ -1,6 +1,6 @@
-## BE_HTTP_PUTData
+## BE_HTTP_PUTFile
 
-    BE_HTTP_PUTData ( url ; path ; { username ; password } )
+    	BE_HTTP_PUTFile ( url ; path ; { username ; password } )
 
 **Description**  
 
@@ -52,6 +52,6 @@ This function has been superseded by the Insert From URL script step, and may be
 
 The type of data being sent is usually determined via a Content_Type header you set via *BE_HTTP_SetCustomHeader*. Each file type will have it's own Content-Type and the web service will determine acceptable types.  
 
-	BE_HTTP_PUTData ( "http://Fictional.Server.com/service.js" ;
+	BE_HTTP_PUTFile ( "http://Fictional.Server.com/service.js" ;
 	"/path/to/file.txt" ;
 	"Administrator" ; "password123" )

--- a/docs/Functions/BE_HTTP_Set_Proxy.md
+++ b/docs/Functions/BE_HTTP_Set_Proxy.md
@@ -1,6 +1,6 @@
-## BE_HTTP_SetProxy
+## BE_HTTP_Set_Proxy
 
-    BE_HTTP_SetProxy ( proxy { ; port ; userName ; password } )
+        BE_HTTP_Set_Proxy ( proxy { ; port ; userName ; password } )
 
 **Description**  
 

--- a/docs/Functions/BE_JSON_ArraySize.md
+++ b/docs/Functions/BE_JSON_ArraySize.md
@@ -9,7 +9,7 @@ Will return the number of values in a JSON array.
 **Parameters**
 
 * *json* : the array to count.
-* *name* ( optional ) : the path within the JSON to locate the array to count.
+* *path* ( optional ) : the path within the JSON to locate the array to count.
 
 **Keywords**  
 

--- a/docs/Functions/BE_SMTPServer.md
+++ b/docs/Functions/BE_SMTPServer.md
@@ -10,7 +10,7 @@ Stores the SMTP connection details for future calls to the *BE_SMTPSend* functio
 
 * *server* : A domain name or IP address of the SMTP server to connect to.
 * *port* : the port number ( a required parameter, but can be an empty string ).
-* *userName* ( optional ) : The userName if the url requires authentication.
+* *username* ( optional ) : The username if the url requires authentication.
 * *password* ( optional ) : The password if the url requires authentication.
 * *keepOpen* ( optional, default:False , ProOnly ) : Whether to keep the connection open for future sends.
 

--- a/docs/Functions/BE_Unzip.md
+++ b/docs/Functions/BE_Unzip.md
@@ -9,7 +9,7 @@ Unzips the archive file found at the path *archiveFilePath*. The unzipped file(s
 **Parameters**
 
 * *archiveFilePath* : a plugin file path, or a container field.
-* *filename* : a system folder path to put the result..
+* *outputFolderPath* : a system folder path to put the result..
 
  If the *archiveFilePath* container field contains text, it's treated as a path to a file.
  

--- a/docs/Functions/BE_XSLTApply.md
+++ b/docs/Functions/BE_XSLTApply.md
@@ -1,6 +1,6 @@
 ## BE_XSLTApply
 
-	BE_XSLT_Apply ( xmlFilePath ; xsltText ; outputFilePath {; scriptName ; databaseName ; [ xsltText ; outputFilePath ] ; ... } )
+		BE_XSLTApply ( xmlFilePath ; xsltText ; outputFilePath {; scriptName ; databaseName ; [ xsltText ; outputFilePath ] ; ... } )
 
 **Description**  
 


### PR DESCRIPTION
Found while cross-checking a function catalog against these docs. Each of the following had a parameter name or code-block signature that didn't match the function's actual name/parameters (mostly copy-paste artifacts):

BE_FileSelectDialog.md / BE_FolderSelectDialog.md: parameter #2 was named `nainFolderPathme`, should be `inFolderPath`.

BE_Encrypt_AES.md: heading, signature, and Keywords section said `BE_Decrypt_AES` / "Decrypt AES".

BE_HTTP_GET_File.md: heading/signature said `BE_HTTP_GET`.

BE_HTTP_GET.md: had a duplicate `username` parameter bullet where the second one should be `filename` (matches the signature's `{ filename ; username ; password }`).

BE_HTTP_PUTFile.md: heading, signature, and example code said `BE_HTTP_PUTData`.

BE_HTTP_Set_Proxy.md: heading/signature said `BE_HTTP_SetProxy`.

BE_SMTPServer.md: parameter #3 was named `userName`, should be `username` (matches the signature).

BE_JSON_ArraySize.md: parameter #2 was named `name`, should be `path` (matches the signature and the Notes section, which already correctly refers to it as *path*).

BE_Unzip.md: parameter #2 was named `filename`, should be `outputFolderPath` (matches the signature).

One note for maintainer review: on BE_HTTP_GET.md, the docs never explained what the `filename` parameter actually does (the function description says it "returns the results" without mentioning a file). I added "The path to save the file to." based on the equivalent parameter in BE_HTTP_GET_File.md, but that's an inference on my part — please verify/adjust the wording if it's not accurate for this function.

Also flagging but not touching in this PR: BE_SignatureVerifyRSA.md has a signature with an unmatched brace (opens with `{`, closes with `)`). I didn't want to guess at the intended fix, so left it as-is; may be worth a follow-up issue.